### PR TITLE
Fix file(s) for singular and plural

### DIFF
--- a/bin/esupgrade.js
+++ b/bin/esupgrade.js
@@ -176,7 +176,7 @@ function processFiles(patterns, options) {
       const totalChanges = allChanges.length
 
       console.log(
-        `${modifiedCount} file(s) need upgrading (${totalChanges} change${totalChanges !== 1 ? "s" : ""}, ${typeCount} type${typeCount !== 1 ? "s" : ""})`,
+        `${modifiedCount} file${modifiedCount !== 1 ? "s" : ""} need${modifiedCount === 1 ? "s" : ""} upgrading (${totalChanges} change${totalChanges !== 1 ? "s" : ""}, ${typeCount} type${typeCount !== 1 ? "s" : ""})`,
       )
       if (options.write) {
         console.log("Changes have been written")
@@ -187,7 +187,7 @@ function processFiles(patterns, options) {
   } else {
     console.log("")
     if (modifiedCount > 0) {
-      console.log(`✓ ${modifiedCount} file(s) upgraded`)
+      console.log(`✓ ${modifiedCount} file${modifiedCount !== 1 ? "s" : ""} upgraded`)
     } else {
       console.log("All files are up to date")
     }

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -46,7 +46,7 @@ describe("CLI", () => {
       /const x = 1/,
       "transforms var to const",
     )
-    assert.match(result.stdout, /✓ 1 file\(s\) upgraded/, "reports 1 file upgraded")
+    assert.match(result.stdout, /✓ 1 file upgraded/, "reports 1 file upgraded")
     assert.equal(result.status, 0, "exits successfully")
   })
 
@@ -113,7 +113,7 @@ describe("CLI", () => {
     assert.match(result.stdout, /✗/, "indicates changes needed")
     assert.match(
       result.stdout,
-      /1 file\(s\) need upgrading/,
+      /1 file needs upgrading/,
       "reports 1 file needs upgrading",
     )
     assert.equal(result.status, 1, "exits with 1 when changes needed")
@@ -178,7 +178,7 @@ describe("CLI", () => {
 
     assert.match(fs.readFileSync(file1, "utf8"), /const x = 1/, "transforms file1")
     assert.match(fs.readFileSync(file2, "utf8"), /const y = 2/, "transforms file2")
-    assert.match(result.stdout, /2 file\(s\) upgraded/, "reports 2 files upgraded")
+    assert.match(result.stdout, /2 files upgraded/, "reports 2 files upgraded")
     assert.equal(result.status, 0, "exits successfully")
   })
 
@@ -215,7 +215,7 @@ describe("CLI", () => {
       encoding: "utf8",
     })
 
-    assert.match(result.stdout, /4 file\(s\) upgraded/, "reports 4 files upgraded")
+    assert.match(result.stdout, /4 files upgraded/, "reports 4 files upgraded")
     assert.equal(result.status, 0, "exits successfully")
   })
 
@@ -290,7 +290,7 @@ describe("CLI", () => {
 
     assert.match(fs.readFileSync(file1, "utf8"), /const x = 1/, "transforms file1")
     assert.match(fs.readFileSync(file2, "utf8"), /const y = 2/, "transforms file2")
-    assert.match(result.stdout, /2 file\(s\) upgraded/, "reports 2 files upgraded")
+    assert.match(result.stdout, /2 files upgraded/, "reports 2 files upgraded")
     assert.equal(result.status, 0, "exits successfully")
   })
 
@@ -388,7 +388,7 @@ describe("CLI", () => {
 
     assert.match(fs.readFileSync(file1, "utf8"), /const x = 1/, "transforms file1")
     assert.match(fs.readFileSync(file2, "utf8"), /const y = 2/, "transforms file2")
-    assert.match(result.stdout, /2 file\(s\) upgraded/, "reports 2 files upgraded")
+    assert.match(result.stdout, /2 files upgraded/, "reports 2 files upgraded")
     assert.equal(result.status, 0, "exits successfully")
   })
 })


### PR DESCRIPTION
Already done for "need"/"needs" and "change"/"changes", also do "file" and "files".