### PR TITLE
Fix #26 -- Correctly handle var transformation for shadowed names

### DIFF
--- a/src/widelyAvailable.js
+++ b/src/widelyAvailable.js
@@ -95,18 +95,27 @@ function isAssignmentShadowed(j, varName, declarationPath, usagePath) {
       // Check for var/let/const declarations in this function
       const functionBody = current.node.body
       if (functionBody) {
+        let foundOurDeclaration = false
         const hasLocalDecl = j(functionBody)
           .find(j.VariableDeclarator)
           .some((declPath) => {
             const declParent = declPath.parent.node
             if (declParent === declarationPath.node) {
+              foundOurDeclaration = true
               return false
             }
             return patternContainsIdentifier(j, declPath.node.id, varName)
           })
 
+        // If we found a shadowing declaration (not our own), the assignment is shadowed
         if (hasLocalDecl) {
           return true
+        }
+
+        // If we found our declaration in this scope, stop traversing -
+        // the assignment is not shadowed, it belongs to our declaration
+        if (foundOurDeclaration) {
+          return false
         }
       }
     }

--- a/tests/widelyAvailable.test.js
+++ b/tests/widelyAvailable.test.js
@@ -721,6 +721,27 @@ var x = 1;`)
       assert.match(result.code, /let a/)
       assert.match(result.code, /let b/)
     })
+
+    test("inner var shadows outer const and is reassigned", () => {
+      const result = transform(`
+    const pixels = [];
+    const obj = {
+      fadePixels: function () {
+        var pixels;
+        for (var i = 0; i < 10; i++) {
+          pixels = getPixels();
+        }
+      }
+    };
+  `)
+
+      assert(result.modified, "inner var shadowing outer const, reassigned in loop")
+      // The outer const pixels should remain const
+      assert.match(result.code, /const pixels = \[\]/)
+      // The inner var pixels should become let (not const) since it's reassigned
+      assert.match(result.code, /let pixels;/)
+      assert.doesNotMatch(result.code, /const pixels;/)
+    })
   })
 
   describe("stringConcatToTemplate", () => {


### PR DESCRIPTION
When a var declaration inside a function shadows an outer const/let/var with the same name, and the inner variable is reassigned (e.g., in a loop), the tool incorrectly converted it to const instead of let.
