### PR TITLE
Increase pre-commit hook performance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,10 +34,12 @@ repos:
     hooks:
       - id: esupgrade
         name: esupgrade
+        description: 'Upgrade your ECMAScript syntax to Baseline.'
         entry: npx .
         args: [--write]
         language: system
-        types_or: [javascript]
+        types_or: [javascript, jsx, ts, tsx]
+        require_serial: true
       - id: prettier
         name: prettier
         entry: prettier --check --write --ignore-unknown
@@ -46,6 +48,7 @@ repos:
         language: node
         additional_dependencies: ["prettier"]
         types_or: [javascript]
+        require_serial: true
 ci:
   autoupdate_schedule: weekly
   skip:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,8 @@
 - id: esupgrade
   name: esupgrade
+  description: 'Upgrade your ECMAScript syntax to Baseline.'
   entry: esupgrade
   args: [--check, --write]
   language: node
   types_or: [javascript, jsx, ts, tsx]
+  require_serial: true


### PR DESCRIPTION
The CLI has buildin multiprocessing and proceses files in a worker
pool. We should run the hook in a single command to use all the
performance optimizations.
