### PR TITLE
Fix #119 -- Preserve comments when applying `iterableForEachToForOf`

### DIFF
--- a/src/widelyAvailable/iterableForEachToForOf.js
+++ b/src/widelyAvailable/iterableForEachToForOf.js
@@ -155,6 +155,17 @@ export function iterableForEachToForOf(root) {
       // Replace the expression statement containing the forEach call
       const statement = path.parent
       if (j.ExpressionStatement.check(statement.node)) {
+        // Preserve comments from the original statement
+        if (statement.node.comments) {
+          forOfLoop.comments = statement.node.comments
+        }
+        if (statement.node.leadingComments) {
+          forOfLoop.leadingComments = statement.node.leadingComments
+        }
+        if (statement.node.trailingComments) {
+          forOfLoop.trailingComments = statement.node.trailingComments
+        }
+
         j(statement).replaceWith(forOfLoop)
 
         modified = true

--- a/src/widelyAvailable/iterableForEachToForOf.js
+++ b/src/widelyAvailable/iterableForEachToForOf.js
@@ -155,17 +155,7 @@ export function iterableForEachToForOf(root) {
       // Replace the expression statement containing the forEach call
       const statement = path.parent
       if (j.ExpressionStatement.check(statement.node)) {
-        // Preserve comments from the original statement
-        if (statement.node.comments) {
-          forOfLoop.comments = statement.node.comments
-        }
-        if (statement.node.leadingComments) {
-          forOfLoop.leadingComments = statement.node.leadingComments
-        }
-        if (statement.node.trailingComments) {
-          forOfLoop.trailingComments = statement.node.trailingComments
-        }
-
+        forOfLoop.comments = statement.node.comments
         j(statement).replaceWith(forOfLoop)
 
         modified = true

--- a/src/widelyAvailable/namedArrowFunctionToNamedFunction.js
+++ b/src/widelyAvailable/namedArrowFunctionToNamedFunction.js
@@ -115,16 +115,7 @@ export function namedArrowFunctionToNamedFunction(root) {
         functionDeclaration.returnType = func.returnType
       }
 
-      // Preserve comments from the original variable declaration
-      if (node.comments) {
-        functionDeclaration.comments = node.comments
-      }
-      if (node.leadingComments) {
-        functionDeclaration.leadingComments = node.leadingComments
-      }
-      if (node.trailingComments) {
-        functionDeclaration.trailingComments = node.trailingComments
-      }
+      functionDeclaration.comments = node.comments
 
       j(path).replaceWith(functionDeclaration)
 

--- a/tests/widelyAvailable/iterable-for-each-to-for-of.test.js
+++ b/tests/widelyAvailable/iterable-for-each-to-for-of.test.js
@@ -465,5 +465,5 @@ process(item);
         "trailing comment should be preserved",
       )
     })
-    })
+  })
 })

--- a/tests/widelyAvailable/iterable-for-each-to-for-of.test.js
+++ b/tests/widelyAvailable/iterable-for-each-to-for-of.test.js
@@ -408,5 +408,62 @@ process(item);
       )
       assert.match(result.code, /for \(const div of document\.body\.querySelectorAll/)
     })
-  })
+
+    test("preserves leading comments", () => {
+      const result = transform(`
+    // Process all test elements with data-test attribute
+    document.querySelectorAll("[data-test]").forEach(function (element) {
+    element.classList.add("processed")
+    })
+    `)
+
+      assert(result.modified, "transform querySelectorAll with leading comment")
+      assert.match(result.code, /for \(const element of document\.querySelectorAll/)
+      assert.match(
+        result.code,
+        /\/\/ Process all test elements with data-test attribute/,
+        "comment should be preserved",
+      )
+    })
+
+    test("preserves trailing comments", () => {
+      const result = transform(`
+    document.querySelectorAll("[data-test]").forEach(function (element) {
+    element.classList.add("processed")
+    })
+    // End of element processing
+    `)
+
+      assert(result.modified, "transform with trailing comment")
+      assert.match(result.code, /for \(const element of document\.querySelectorAll/)
+      assert.match(
+        result.code,
+        /\/\/ End of element processing/,
+        "trailing comment should be preserved",
+      )
+    })
+
+    test("preserves multiple comments", () => {
+      const result = transform(`
+    // Start processing
+    document.querySelectorAll("[data-test]").forEach(function(item) {
+    console.log(item)
+    })
+    // Done processing
+    `)
+
+      assert(result.modified, "transform with leading and trailing comments")
+      assert.match(result.code, /for \(const item of document\.querySelectorAll/)
+      assert.match(
+        result.code,
+        /\/\/ Start processing/,
+        "leading comment should be preserved",
+      )
+      assert.match(
+        result.code,
+        /\/\/ Done processing/,
+        "trailing comment should be preserved",
+      )
+    })
+    })
 })


### PR DESCRIPTION
Hey Johannes,

here is my attempt to fix issue #119 that we experienced when running your package on our project.

I am not sure about your way of writing tests, but I tried my best here. Feel free to alter the code if you want to iterate on it quickly.

Best,
Rust
