### PR TITLE
Harden `constructorToClass` scope resolution and ambiguity handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ Transforms constructor functions (both function declarations and variable declar
 
 - Function name starts with an uppercase letter
 - At least one prototype method is defined
+- Prototype methods are matched within the same lexical scope as the constructor declaration
 - Prototype methods using `this` in arrow functions are skipped
 - Prototype object literals with getters, setters, or computed properties are skipped
 

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ Transforms constructor functions (both function declarations and variable declar
 
 - Function name starts with an uppercase letter
 - At least one prototype method is defined
-- Prototype methods are matched within the same lexical scope as the constructor declaration
+- Prototype methods are matched only to constructors declared in the current or an ancestor lexical scope (never sibling or child scopes)
 - Prototype methods using `this` in arrow functions are skipped
 - Prototype object literals with getters, setters, or computed properties are skipped
 

--- a/src/widelyAvailable/constructorToClass.js
+++ b/src/widelyAvailable/constructorToClass.js
@@ -8,14 +8,20 @@ function getDeclarationScope(path) {
 }
 
 function addConstructor(constructorsByScope, constructorName, declarationPath) {
+  const scopeNode = getDeclarationScope(declarationPath).path.node
+  const constructorsInScope = constructorsByScope.get(scopeNode) ?? new Map()
+
+  if (constructorsInScope.has(constructorName)) {
+    constructorsInScope.set(constructorName, null)
+    constructorsByScope.set(scopeNode, constructorsInScope)
+    return
+  }
+
   const constructorInfo = {
     constructorName,
     declaration: declarationPath,
     prototypeMethods: [],
   }
-
-  const scopeNode = getDeclarationScope(declarationPath).path.node
-  const constructorsInScope = constructorsByScope.get(scopeNode) ?? new Map()
 
   constructorsInScope.set(constructorName, constructorInfo)
   constructorsByScope.set(scopeNode, constructorsInScope)
@@ -52,7 +58,10 @@ function findConstructors(root) {
     addConstructor(constructorsByScope, path.node.id.name, path)
   })
 
-  root.find(j.VariableDeclaration).forEach((path) => {
+  root
+    .find(j.VariableDeclaration)
+    .filter((path) => path.node.declarations.length === 1)
+    .forEach((path) => {
     path.node.declarations.forEach((declarator) => {
       if (
         !new NodeTest(declarator.id).isConstructorName() ||
@@ -90,11 +99,11 @@ function findPrototypeMethods(root, constructorsByScope) {
   // Pattern 1: ConstructorName.prototype.methodName = ...
   root
     .find(j.ExpressionStatement)
-    .filter((path) => {
+    .forEach((path) => {
       const { node } = path
 
       if (!j.AssignmentExpression.check(node.expression)) {
-        return false
+        return
       }
 
       const assignment = node.expression
@@ -108,24 +117,22 @@ function findPrototypeMethods(root, constructorsByScope) {
         left.object.property.name !== "prototype" ||
         !j.Identifier.check(left.property)
       ) {
-        return false
+        return
       }
 
       const constructorName = left.object.object.name
-      return !!getConstructor(constructorsByScope, path, constructorName)
-    })
-    .forEach((path) => {
-      const assignment = path.node.expression
-      const left = assignment.left
-      const constructorName = left.object.object.name
+      const constructorInfo = getConstructor(constructorsByScope, path, constructorName)
+
+      if (!constructorInfo) {
+        return
+      }
+
       const methodName = left.property.name
       const methodValue = assignment.right
 
       if (!new NodeTest(methodValue).canBeClassMethod()) {
         return
       }
-
-      const constructorInfo = getConstructor(constructorsByScope, path, constructorName)
 
       constructorInfo.prototypeMethods.push({
         path,
@@ -137,11 +144,11 @@ function findPrototypeMethods(root, constructorsByScope) {
   // Pattern 2: ConstructorName.prototype = { methodName: function() {...}, ... }
   root
     .find(j.ExpressionStatement)
-    .filter((path) => {
+    .forEach((path) => {
       const { node } = path
 
       if (!j.AssignmentExpression.check(node.expression)) {
-        return false
+        return
       }
 
       const assignment = node.expression
@@ -153,23 +160,21 @@ function findPrototypeMethods(root, constructorsByScope) {
         !j.Identifier.check(left.property) ||
         left.property.name !== "prototype"
       ) {
-        return false
+        return
       }
 
       const constructorName = left.object.name
-      return !!getConstructor(constructorsByScope, path, constructorName)
-    })
-    .forEach((path) => {
-      const assignment = path.node.expression
-      const left = assignment.left
-      const constructorName = left.object.name
+      const constructorInfo = getConstructor(constructorsByScope, path, constructorName)
+
+      if (!constructorInfo) {
+        return
+      }
+
       const methodValue = assignment.right
 
       if (!j.ObjectExpression.check(methodValue)) {
         return
       }
-
-      const constructorInfo = getConstructor(constructorsByScope, path, constructorName)
 
       methodValue.properties.forEach((prop) => {
         if (!j.Property.check(prop) && !j.ObjectProperty.check(prop)) {
@@ -225,7 +230,7 @@ function transformConstructorsToClasses(root, constructorsByScope) {
 
   constructorsByScope.forEach((constructors) => {
     constructors.forEach((info) => {
-      if (info.prototypeMethods.length === 0) {
+      if (!info || info.prototypeMethods.length === 0) {
         return
       }
 

--- a/src/widelyAvailable/constructorToClass.js
+++ b/src/widelyAvailable/constructorToClass.js
@@ -62,18 +62,18 @@ function findConstructors(root) {
     .find(j.VariableDeclaration)
     .filter((path) => path.node.declarations.length === 1)
     .forEach((path) => {
-    path.node.declarations.forEach((declarator) => {
-      if (
-        !new NodeTest(declarator.id).isConstructorName() ||
-        !j.FunctionExpression.check(declarator.init) ||
-        !new NodeTest(declarator.init.body).hasSimpleConstructorBody()
-      ) {
-        return
-      }
+      path.node.declarations.forEach((declarator) => {
+        if (
+          !new NodeTest(declarator.id).isConstructorName() ||
+          !j.FunctionExpression.check(declarator.init) ||
+          !new NodeTest(declarator.init.body).hasSimpleConstructorBody()
+        ) {
+          return
+        }
 
-      addConstructor(constructorsByScope, declarator.id.name, path)
+        addConstructor(constructorsByScope, declarator.id.name, path)
+      })
     })
-  })
 
   return constructorsByScope
 }
@@ -97,113 +97,109 @@ function findConstructors(root) {
  */
 function findPrototypeMethods(root, constructorsByScope) {
   // Pattern 1: ConstructorName.prototype.methodName = ...
-  root
-    .find(j.ExpressionStatement)
-    .forEach((path) => {
-      const { node } = path
+  root.find(j.ExpressionStatement).forEach((path) => {
+    const { node } = path
 
-      if (!j.AssignmentExpression.check(node.expression)) {
+    if (!j.AssignmentExpression.check(node.expression)) {
+      return
+    }
+
+    const assignment = node.expression
+    const left = assignment.left
+
+    if (
+      !j.MemberExpression.check(left) ||
+      !j.MemberExpression.check(left.object) ||
+      !j.Identifier.check(left.object.object) ||
+      !j.Identifier.check(left.object.property) ||
+      left.object.property.name !== "prototype" ||
+      !j.Identifier.check(left.property)
+    ) {
+      return
+    }
+
+    const constructorName = left.object.object.name
+    const constructorInfo = getConstructor(constructorsByScope, path, constructorName)
+
+    if (!constructorInfo) {
+      return
+    }
+
+    const methodName = left.property.name
+    const methodValue = assignment.right
+
+    if (!new NodeTest(methodValue).canBeClassMethod()) {
+      return
+    }
+
+    constructorInfo.prototypeMethods.push({
+      path,
+      methodName,
+      methodValue,
+    })
+  })
+
+  // Pattern 2: ConstructorName.prototype = { methodName: function() {...}, ... }
+  root.find(j.ExpressionStatement).forEach((path) => {
+    const { node } = path
+
+    if (!j.AssignmentExpression.check(node.expression)) {
+      return
+    }
+
+    const assignment = node.expression
+    const left = assignment.left
+
+    if (
+      !j.MemberExpression.check(left) ||
+      !j.Identifier.check(left.object) ||
+      !j.Identifier.check(left.property) ||
+      left.property.name !== "prototype"
+    ) {
+      return
+    }
+
+    const constructorName = left.object.name
+    const constructorInfo = getConstructor(constructorsByScope, path, constructorName)
+
+    if (!constructorInfo) {
+      return
+    }
+
+    const methodValue = assignment.right
+
+    if (!j.ObjectExpression.check(methodValue)) {
+      return
+    }
+
+    methodValue.properties.forEach((prop) => {
+      if (!j.Property.check(prop) && !j.ObjectProperty.check(prop)) {
         return
       }
 
-      const assignment = node.expression
-      const left = assignment.left
-
-      if (
-        !j.MemberExpression.check(left) ||
-        !j.MemberExpression.check(left.object) ||
-        !j.Identifier.check(left.object.object) ||
-        !j.Identifier.check(left.object.property) ||
-        left.object.property.name !== "prototype" ||
-        !j.Identifier.check(left.property)
-      ) {
+      if (prop.computed) {
         return
       }
 
-      const constructorName = left.object.object.name
-      const constructorInfo = getConstructor(constructorsByScope, path, constructorName)
-
-      if (!constructorInfo) {
+      let methodName
+      if (j.Identifier.check(prop.key)) {
+        methodName = prop.key.name
+      } else {
         return
       }
 
-      const methodName = left.property.name
-      const methodValue = assignment.right
-
-      if (!new NodeTest(methodValue).canBeClassMethod()) {
+      if (!new NodeTest(prop.value).canBeClassMethod()) {
         return
       }
 
       constructorInfo.prototypeMethods.push({
         path,
         methodName,
-        methodValue,
+        methodValue: prop.value,
+        isObjectLiteral: true,
       })
     })
-
-  // Pattern 2: ConstructorName.prototype = { methodName: function() {...}, ... }
-  root
-    .find(j.ExpressionStatement)
-    .forEach((path) => {
-      const { node } = path
-
-      if (!j.AssignmentExpression.check(node.expression)) {
-        return
-      }
-
-      const assignment = node.expression
-      const left = assignment.left
-
-      if (
-        !j.MemberExpression.check(left) ||
-        !j.Identifier.check(left.object) ||
-        !j.Identifier.check(left.property) ||
-        left.property.name !== "prototype"
-      ) {
-        return
-      }
-
-      const constructorName = left.object.name
-      const constructorInfo = getConstructor(constructorsByScope, path, constructorName)
-
-      if (!constructorInfo) {
-        return
-      }
-
-      const methodValue = assignment.right
-
-      if (!j.ObjectExpression.check(methodValue)) {
-        return
-      }
-
-      methodValue.properties.forEach((prop) => {
-        if (!j.Property.check(prop) && !j.ObjectProperty.check(prop)) {
-          return
-        }
-
-        if (prop.computed) {
-          return
-        }
-
-        let methodName
-        if (j.Identifier.check(prop.key)) {
-          methodName = prop.key.name
-        } else {
-          return
-        }
-
-        if (!new NodeTest(prop.value).canBeClassMethod()) {
-          return
-        }
-
-        constructorInfo.prototypeMethods.push({
-          path,
-          methodName,
-          methodValue: prop.value,
-          isObjectLiteral: true,
-        })
-      })
-    })
+  })
 }
 
 /**

--- a/src/widelyAvailable/constructorToClass.js
+++ b/src/widelyAvailable/constructorToClass.js
@@ -10,8 +10,45 @@ import { NodeTest } from "../types.js"
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes
  */
 export function constructorToClass(root) {
+  function getDeclarationScope(path) {
+    return j.FunctionDeclaration.check(path.node)
+      ? (path.scope.parent ?? path.scope)
+      : path.scope
+  }
+
+  function addConstructor(constructorsByScope, constructorName, declarationPath) {
+    const constructorInfo = {
+      constructorName,
+      declaration: declarationPath,
+      prototypeMethods: [],
+    }
+
+    const scopeNode = getDeclarationScope(declarationPath).path.node
+    const constructorsInScope = constructorsByScope.get(scopeNode) ?? new Map()
+
+    constructorsInScope.set(constructorName, constructorInfo)
+    constructorsByScope.set(scopeNode, constructorsInScope)
+  }
+
+  function getConstructor(constructorsByScope, path, constructorName) {
+    let activeScope = path.scope
+
+    while (activeScope) {
+      const constructorsInScope = constructorsByScope.get(activeScope.path.node)
+      const constructorInfo = constructorsInScope?.get(constructorName)
+
+      if (constructorInfo) {
+        return constructorInfo
+      }
+
+      activeScope = activeScope.parent
+    }
+
+    return null
+  }
+
   function findConstructors(root) {
-    const constructors = new Map()
+    const constructorsByScope = new Map()
 
     root.find(j.FunctionDeclaration).forEach((path) => {
       if (
@@ -21,10 +58,7 @@ export function constructorToClass(root) {
         return
       }
 
-      constructors.set(path.node.id.name, {
-        declaration: path,
-        prototypeMethods: [],
-      })
+      addConstructor(constructorsByScope, path.node.id.name, path)
     })
 
     root.find(j.VariableDeclaration).forEach((path) => {
@@ -37,14 +71,11 @@ export function constructorToClass(root) {
           return
         }
 
-        constructors.set(declarator.id.name, {
-          declaration: path,
-          prototypeMethods: [],
-        })
+        addConstructor(constructorsByScope, declarator.id.name, path)
       })
     })
 
-    return constructors
+    return constructorsByScope
   }
 
   /**
@@ -52,16 +83,25 @@ export function constructorToClass(root) {
    *
    * @param {import("jscodeshift").Collection} root - The root AST collection.
    * @param {Map<
-   *   string,
-   *   { declaration: import("ast-types").NodePath; prototypeMethods: any[] }
-   * >} constructors
-   *   - Map of constructors.
+   *   object,
+   *   Map<
+   *     string,
+   *     {
+   *       constructorName: string
+   *       declaration: import("ast-types").NodePath
+   *       prototypeMethods: any[]
+   *     }
+   *   >
+   * >} constructorsByScope
+   *   - Map of constructors grouped by lexical scope.
    */
-  function findPrototypeMethods(root, constructors) {
+  function findPrototypeMethods(root, constructorsByScope) {
     // Pattern 1: ConstructorName.prototype.methodName = ...
     root
       .find(j.ExpressionStatement)
-      .filter(({ node }) => {
+      .filter((path) => {
+        const { node } = path
+
         if (!j.AssignmentExpression.check(node.expression)) {
           return false
         }
@@ -81,7 +121,7 @@ export function constructorToClass(root) {
         }
 
         const constructorName = left.object.object.name
-        return constructors.has(constructorName)
+        return !!getConstructor(constructorsByScope, path, constructorName)
       })
       .forEach((path) => {
         const assignment = path.node.expression
@@ -94,7 +134,13 @@ export function constructorToClass(root) {
           return
         }
 
-        constructors.get(constructorName).prototypeMethods.push({
+        const constructorInfo = getConstructor(
+          constructorsByScope,
+          path,
+          constructorName,
+        )
+
+        constructorInfo.prototypeMethods.push({
           path,
           methodName,
           methodValue,
@@ -104,7 +150,9 @@ export function constructorToClass(root) {
     // Pattern 2: ConstructorName.prototype = { methodName: function() {...}, ... }
     root
       .find(j.ExpressionStatement)
-      .filter(({ node }) => {
+      .filter((path) => {
+        const { node } = path
+
         if (!j.AssignmentExpression.check(node.expression)) {
           return false
         }
@@ -122,7 +170,7 @@ export function constructorToClass(root) {
         }
 
         const constructorName = left.object.name
-        return constructors.has(constructorName)
+        return !!getConstructor(constructorsByScope, path, constructorName)
       })
       .forEach((path) => {
         const assignment = path.node.expression
@@ -133,6 +181,12 @@ export function constructorToClass(root) {
         if (!j.ObjectExpression.check(methodValue)) {
           return
         }
+
+        const constructorInfo = getConstructor(
+          constructorsByScope,
+          path,
+          constructorName,
+        )
 
         methodValue.properties.forEach((prop) => {
           if (!j.Property.check(prop) && !j.ObjectProperty.check(prop)) {
@@ -154,7 +208,7 @@ export function constructorToClass(root) {
             return
           }
 
-          constructors.get(constructorName).prototypeMethods.push({
+          constructorInfo.prototypeMethods.push({
             path,
             methodName,
             methodValue: prop.value,
@@ -169,97 +223,107 @@ export function constructorToClass(root) {
    *
    * @param {import("jscodeshift").Collection} root - The root AST collection.
    * @param {Map<
-   *   string,
-   *   { declaration: import("ast-types").NodePath; prototypeMethods: any[] }
-   * >} constructors
-   *   - Map of constructors.
+   *   object,
+   *   Map<
+   *     string,
+   *     {
+   *       constructorName: string
+   *       declaration: import("ast-types").NodePath
+   *       prototypeMethods: any[]
+   *     }
+   *   >
+   * >} constructorsByScope
+   *   - Map of constructors grouped by lexical scope.
    *
    * @returns {boolean} True if code was modified.
    */
-  function transformConstructorsToClasses(root, constructors) {
+  function transformConstructorsToClasses(root, constructorsByScope) {
     let modified = false
 
-    constructors.forEach((info, constructorName) => {
-      if (info.prototypeMethods.length === 0) {
-        return
-      }
-
-      const declarationPath = info.declaration
-      const declarationNode = declarationPath.node
-
-      let constructorNode
-      if (j.FunctionDeclaration.check(declarationNode)) {
-        constructorNode = declarationNode
-      } else {
-        const declarator = declarationNode.declarations.find(
-          (decl) => decl.id.name === constructorName,
-        )
-        constructorNode = declarator.init
-      }
-
-      const classBody = [
-        j.methodDefinition(
-          "constructor",
-          j.identifier("constructor"),
-          j.functionExpression(
-            null,
-            constructorNode.params,
-            constructorNode.body,
-            constructorNode.generator,
-            constructorNode.async,
-          ),
-          false,
-        ),
-      ]
-
-      info.prototypeMethods.forEach(({ methodName, methodValue }) => {
-        const functionExpr = j.functionExpression(
-          null,
-          methodValue.params,
-          new NodeTest(methodValue).toBlockStatement(),
-          methodValue.generator || false,
-        )
-
-        // Preserve async property
-        if (methodValue.async) {
-          functionExpr.async = true
+    constructorsByScope.forEach((constructors) => {
+      constructors.forEach((info) => {
+        if (info.prototypeMethods.length === 0) {
+          return
         }
 
-        const method = j.methodDefinition(
-          "method",
-          j.identifier(methodName),
-          functionExpr,
-          false,
+        const constructorName = info.constructorName
+        const declarationPath = info.declaration
+        const declarationNode = declarationPath.node
+
+        let constructorNode
+        if (j.FunctionDeclaration.check(declarationNode)) {
+          constructorNode = declarationNode
+        } else {
+          const declarator = declarationNode.declarations.find(
+            (decl) => decl.id.name === constructorName,
+          )
+          constructorNode = declarator.init
+        }
+
+        const classBody = [
+          j.methodDefinition(
+            "constructor",
+            j.identifier("constructor"),
+            j.functionExpression(
+              null,
+              constructorNode.params,
+              constructorNode.body,
+              constructorNode.generator,
+              constructorNode.async,
+            ),
+            false,
+          ),
+        ]
+
+        info.prototypeMethods.forEach(({ methodName, methodValue }) => {
+          const functionExpr = j.functionExpression(
+            null,
+            methodValue.params,
+            new NodeTest(methodValue).toBlockStatement(),
+            methodValue.generator || false,
+          )
+
+          // Preserve async property
+          if (methodValue.async) {
+            functionExpr.async = true
+          }
+
+          const method = j.methodDefinition(
+            "method",
+            j.identifier(methodName),
+            functionExpr,
+            false,
+          )
+          classBody.push(method)
+        })
+
+        const classDeclaration = j.classDeclaration(
+          j.identifier(constructorName),
+          j.classBody(classBody),
         )
-        classBody.push(method)
+
+        classDeclaration.comments = declarationNode.comments
+
+        j(info.declaration).replaceWith(classDeclaration)
+
+        const pathsToRemove = new Set()
+        info.prototypeMethods.forEach(({ path }) => {
+          pathsToRemove.add(path)
+        })
+
+        pathsToRemove.forEach((path) => {
+          j(path).remove()
+        })
+
+        modified = true
       })
-
-      const classDeclaration = j.classDeclaration(
-        j.identifier(constructorName),
-        j.classBody(classBody),
-      )
-
-      classDeclaration.comments = declarationNode.comments
-
-      j(info.declaration).replaceWith(classDeclaration)
-
-      const pathsToRemove = new Set()
-      info.prototypeMethods.forEach(({ path }) => {
-        pathsToRemove.add(path)
-      })
-
-      pathsToRemove.forEach((path) => {
-        j(path).remove()
-      })
-
-      modified = true
     })
 
     return modified
   }
 
-  const constructors = findConstructors(root)
-  findPrototypeMethods(root, constructors)
-  return transformConstructorsToClasses(root, constructors)
+  const constructorsByScope = findConstructors(root)
+  findPrototypeMethods(root, constructorsByScope)
+  return transformConstructorsToClasses(root, constructorsByScope)
 }
 constructorToClass.baselineDate = new Date(Date.UTC(2016, 2, 8))

--- a/src/widelyAvailable/constructorToClass.js
+++ b/src/widelyAvailable/constructorToClass.js
@@ -32,10 +32,10 @@ function getConstructor(constructorsByScope, path, constructorName) {
 
   while (activeScope) {
     const constructorsInScope = constructorsByScope.get(activeScope.path.node)
-    const constructorInfo = constructorsInScope?.get(constructorName)
+    const hasConstructorInScope = constructorsInScope?.has(constructorName)
 
-    if (constructorInfo) {
-      return constructorInfo
+    if (hasConstructorInScope) {
+      return constructorsInScope.get(constructorName)
     }
 
     activeScope = activeScope.parent

--- a/src/widelyAvailable/constructorToClass.js
+++ b/src/widelyAvailable/constructorToClass.js
@@ -1,6 +1,310 @@
 import { default as j } from "jscodeshift"
 import { NodeTest } from "../types.js"
 
+function getDeclarationScope(path) {
+  return j.FunctionDeclaration.check(path.node)
+    ? (path.scope.parent ?? path.scope)
+    : path.scope
+}
+
+function addConstructor(constructorsByScope, constructorName, declarationPath) {
+  const constructorInfo = {
+    constructorName,
+    declaration: declarationPath,
+    prototypeMethods: [],
+  }
+
+  const scopeNode = getDeclarationScope(declarationPath).path.node
+  const constructorsInScope = constructorsByScope.get(scopeNode) ?? new Map()
+
+  constructorsInScope.set(constructorName, constructorInfo)
+  constructorsByScope.set(scopeNode, constructorsInScope)
+}
+
+function getConstructor(constructorsByScope, path, constructorName) {
+  let activeScope = path.scope
+
+  while (activeScope) {
+    const constructorsInScope = constructorsByScope.get(activeScope.path.node)
+    const constructorInfo = constructorsInScope?.get(constructorName)
+
+    if (constructorInfo) {
+      return constructorInfo
+    }
+
+    activeScope = activeScope.parent
+  }
+
+  return null
+}
+
+function findConstructors(root) {
+  const constructorsByScope = new Map()
+
+  root.find(j.FunctionDeclaration).forEach((path) => {
+    if (
+      !new NodeTest(path.node.id).isConstructorName() ||
+      !new NodeTest(path.node.body).hasSimpleConstructorBody()
+    ) {
+      return
+    }
+
+    addConstructor(constructorsByScope, path.node.id.name, path)
+  })
+
+  root.find(j.VariableDeclaration).forEach((path) => {
+    path.node.declarations.forEach((declarator) => {
+      if (
+        !new NodeTest(declarator.id).isConstructorName() ||
+        !j.FunctionExpression.check(declarator.init) ||
+        !new NodeTest(declarator.init.body).hasSimpleConstructorBody()
+      ) {
+        return
+      }
+
+      addConstructor(constructorsByScope, declarator.id.name, path)
+    })
+  })
+
+  return constructorsByScope
+}
+
+/**
+ * Find and associate prototype methods with constructors.
+ *
+ * @param {import("jscodeshift").Collection} root - The root AST collection.
+ * @param {Map<
+ *   object,
+ *   Map<
+ *     string,
+ *     {
+ *       constructorName: string
+ *       declaration: import("ast-types").NodePath
+ *       prototypeMethods: any[]
+ *     }
+ *   >
+ * >} constructorsByScope
+ *   - Map of constructors grouped by lexical scope.
+ */
+function findPrototypeMethods(root, constructorsByScope) {
+  // Pattern 1: ConstructorName.prototype.methodName = ...
+  root
+    .find(j.ExpressionStatement)
+    .filter((path) => {
+      const { node } = path
+
+      if (!j.AssignmentExpression.check(node.expression)) {
+        return false
+      }
+
+      const assignment = node.expression
+      const left = assignment.left
+
+      if (
+        !j.MemberExpression.check(left) ||
+        !j.MemberExpression.check(left.object) ||
+        !j.Identifier.check(left.object.object) ||
+        !j.Identifier.check(left.object.property) ||
+        left.object.property.name !== "prototype" ||
+        !j.Identifier.check(left.property)
+      ) {
+        return false
+      }
+
+      const constructorName = left.object.object.name
+      return !!getConstructor(constructorsByScope, path, constructorName)
+    })
+    .forEach((path) => {
+      const assignment = path.node.expression
+      const left = assignment.left
+      const constructorName = left.object.object.name
+      const methodName = left.property.name
+      const methodValue = assignment.right
+
+      if (!new NodeTest(methodValue).canBeClassMethod()) {
+        return
+      }
+
+      const constructorInfo = getConstructor(constructorsByScope, path, constructorName)
+
+      constructorInfo.prototypeMethods.push({
+        path,
+        methodName,
+        methodValue,
+      })
+    })
+
+  // Pattern 2: ConstructorName.prototype = { methodName: function() {...}, ... }
+  root
+    .find(j.ExpressionStatement)
+    .filter((path) => {
+      const { node } = path
+
+      if (!j.AssignmentExpression.check(node.expression)) {
+        return false
+      }
+
+      const assignment = node.expression
+      const left = assignment.left
+
+      if (
+        !j.MemberExpression.check(left) ||
+        !j.Identifier.check(left.object) ||
+        !j.Identifier.check(left.property) ||
+        left.property.name !== "prototype"
+      ) {
+        return false
+      }
+
+      const constructorName = left.object.name
+      return !!getConstructor(constructorsByScope, path, constructorName)
+    })
+    .forEach((path) => {
+      const assignment = path.node.expression
+      const left = assignment.left
+      const constructorName = left.object.name
+      const methodValue = assignment.right
+
+      if (!j.ObjectExpression.check(methodValue)) {
+        return
+      }
+
+      const constructorInfo = getConstructor(constructorsByScope, path, constructorName)
+
+      methodValue.properties.forEach((prop) => {
+        if (!j.Property.check(prop) && !j.ObjectProperty.check(prop)) {
+          return
+        }
+
+        if (prop.computed) {
+          return
+        }
+
+        let methodName
+        if (j.Identifier.check(prop.key)) {
+          methodName = prop.key.name
+        } else {
+          return
+        }
+
+        if (!new NodeTest(prop.value).canBeClassMethod()) {
+          return
+        }
+
+        constructorInfo.prototypeMethods.push({
+          path,
+          methodName,
+          methodValue: prop.value,
+          isObjectLiteral: true,
+        })
+      })
+    })
+}
+
+/**
+ * Transform constructors and their prototype methods to class syntax.
+ *
+ * @param {import("jscodeshift").Collection} root - The root AST collection.
+ * @param {Map<
+ *   object,
+ *   Map<
+ *     string,
+ *     {
+ *       constructorName: string
+ *       declaration: import("ast-types").NodePath
+ *       prototypeMethods: any[]
+ *     }
+ *   >
+ * >} constructorsByScope
+ *   - Map of constructors grouped by lexical scope.
+ *
+ * @returns {boolean} True if code was modified.
+ */
+function transformConstructorsToClasses(root, constructorsByScope) {
+  let modified = false
+
+  constructorsByScope.forEach((constructors) => {
+    constructors.forEach((info) => {
+      if (info.prototypeMethods.length === 0) {
+        return
+      }
+
+      const constructorName = info.constructorName
+      const declarationPath = info.declaration
+      const declarationNode = declarationPath.node
+
+      let constructorNode
+      if (j.FunctionDeclaration.check(declarationNode)) {
+        constructorNode = declarationNode
+      } else {
+        const declarator = declarationNode.declarations.find(
+          (decl) => decl.id.name === constructorName,
+        )
+        constructorNode = declarator.init
+      }
+
+      const classBody = [
+        j.methodDefinition(
+          "constructor",
+          j.identifier("constructor"),
+          j.functionExpression(
+            null,
+            constructorNode.params,
+            constructorNode.body,
+            constructorNode.generator,
+            constructorNode.async,
+          ),
+          false,
+        ),
+      ]
+
+      info.prototypeMethods.forEach(({ methodName, methodValue }) => {
+        const functionExpr = j.functionExpression(
+          null,
+          methodValue.params,
+          new NodeTest(methodValue).toBlockStatement(),
+          methodValue.generator || false,
+        )
+
+        // Preserve async property
+        if (methodValue.async) {
+          functionExpr.async = true
+        }
+
+        const method = j.methodDefinition(
+          "method",
+          j.identifier(methodName),
+          functionExpr,
+          false,
+        )
+        classBody.push(method)
+      })
+
+      const classDeclaration = j.classDeclaration(
+        j.identifier(constructorName),
+        j.classBody(classBody),
+      )
+
+      classDeclaration.comments = declarationNode.comments
+
+      j(info.declaration).replaceWith(classDeclaration)
+
+      const pathsToRemove = new Set()
+      info.prototypeMethods.forEach(({ path }) => {
+        pathsToRemove.add(path)
+      })
+
+      pathsToRemove.forEach((path) => {
+        j(path).remove()
+      })
+
+      modified = true
+    })
+  })
+
+  return modified
+}
+
 /**
  * Transform old-school constructor functions with prototype methods to ES6 class
  * syntax.
@@ -10,318 +314,6 @@ import { NodeTest } from "../types.js"
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes
  */
 export function constructorToClass(root) {
-  function getDeclarationScope(path) {
-    return j.FunctionDeclaration.check(path.node)
-      ? (path.scope.parent ?? path.scope)
-      : path.scope
-  }
-
-  function addConstructor(constructorsByScope, constructorName, declarationPath) {
-    const constructorInfo = {
-      constructorName,
-      declaration: declarationPath,
-      prototypeMethods: [],
-    }
-
-    const scopeNode = getDeclarationScope(declarationPath).path.node
-    const constructorsInScope = constructorsByScope.get(scopeNode) ?? new Map()
-
-    constructorsInScope.set(constructorName, constructorInfo)
-    constructorsByScope.set(scopeNode, constructorsInScope)
-  }
-
-  function getConstructor(constructorsByScope, path, constructorName) {
-    let activeScope = path.scope
-
-    while (activeScope) {
-      const constructorsInScope = constructorsByScope.get(activeScope.path.node)
-      const constructorInfo = constructorsInScope?.get(constructorName)
-
-      if (constructorInfo) {
-        return constructorInfo
-      }
-
-      activeScope = activeScope.parent
-    }
-
-    return null
-  }
-
-  function findConstructors(root) {
-    const constructorsByScope = new Map()
-
-    root.find(j.FunctionDeclaration).forEach((path) => {
-      if (
-        !new NodeTest(path.node.id).isConstructorName() ||
-        !new NodeTest(path.node.body).hasSimpleConstructorBody()
-      ) {
-        return
-      }
-
-      addConstructor(constructorsByScope, path.node.id.name, path)
-    })
-
-    root.find(j.VariableDeclaration).forEach((path) => {
-      path.node.declarations.forEach((declarator) => {
-        if (
-          !new NodeTest(declarator.id).isConstructorName() ||
-          !j.FunctionExpression.check(declarator.init) ||
-          !new NodeTest(declarator.init.body).hasSimpleConstructorBody()
-        ) {
-          return
-        }
-
-        addConstructor(constructorsByScope, declarator.id.name, path)
-      })
-    })
-
-    return constructorsByScope
-  }
-
-  /**
-   * Find and associate prototype methods with constructors.
-   *
-   * @param {import("jscodeshift").Collection} root - The root AST collection.
-   * @param {Map<
-   *   object,
-   *   Map<
-   *     string,
-   *     {
-   *       constructorName: string
-   *       declaration: import("ast-types").NodePath
-   *       prototypeMethods: any[]
-   *     }
-   *   >
-   * >} constructorsByScope
-   *   - Map of constructors grouped by lexical scope.
-   */
-  function findPrototypeMethods(root, constructorsByScope) {
-    // Pattern 1: ConstructorName.prototype.methodName = ...
-    root
-      .find(j.ExpressionStatement)
-      .filter((path) => {
-        const { node } = path
-
-        if (!j.AssignmentExpression.check(node.expression)) {
-          return false
-        }
-
-        const assignment = node.expression
-        const left = assignment.left
-
-        if (
-          !j.MemberExpression.check(left) ||
-          !j.MemberExpression.check(left.object) ||
-          !j.Identifier.check(left.object.object) ||
-          !j.Identifier.check(left.object.property) ||
-          left.object.property.name !== "prototype" ||
-          !j.Identifier.check(left.property)
-        ) {
-          return false
-        }
-
-        const constructorName = left.object.object.name
-        return !!getConstructor(constructorsByScope, path, constructorName)
-      })
-      .forEach((path) => {
-        const assignment = path.node.expression
-        const left = assignment.left
-        const constructorName = left.object.object.name
-        const methodName = left.property.name
-        const methodValue = assignment.right
-
-        if (!new NodeTest(methodValue).canBeClassMethod()) {
-          return
-        }
-
-        const constructorInfo = getConstructor(
-          constructorsByScope,
-          path,
-          constructorName,
-        )
-
-        constructorInfo.prototypeMethods.push({
-          path,
-          methodName,
-          methodValue,
-        })
-      })
-
-    // Pattern 2: ConstructorName.prototype = { methodName: function() {...}, ... }
-    root
-      .find(j.ExpressionStatement)
-      .filter((path) => {
-        const { node } = path
-
-        if (!j.AssignmentExpression.check(node.expression)) {
-          return false
-        }
-
-        const assignment = node.expression
-        const left = assignment.left
-
-        if (
-          !j.MemberExpression.check(left) ||
-          !j.Identifier.check(left.object) ||
-          !j.Identifier.check(left.property) ||
-          left.property.name !== "prototype"
-        ) {
-          return false
-        }
-
-        const constructorName = left.object.name
-        return !!getConstructor(constructorsByScope, path, constructorName)
-      })
-      .forEach((path) => {
-        const assignment = path.node.expression
-        const left = assignment.left
-        const constructorName = left.object.name
-        const methodValue = assignment.right
-
-        if (!j.ObjectExpression.check(methodValue)) {
-          return
-        }
-
-        const constructorInfo = getConstructor(
-          constructorsByScope,
-          path,
-          constructorName,
-        )
-
-        methodValue.properties.forEach((prop) => {
-          if (!j.Property.check(prop) && !j.ObjectProperty.check(prop)) {
-            return
-          }
-
-          if (prop.computed) {
-            return
-          }
-
-          let methodName
-          if (j.Identifier.check(prop.key)) {
-            methodName = prop.key.name
-          } else {
-            return
-          }
-
-          if (!new NodeTest(prop.value).canBeClassMethod()) {
-            return
-          }
-
-          constructorInfo.prototypeMethods.push({
-            path,
-            methodName,
-            methodValue: prop.value,
-            isObjectLiteral: true,
-          })
-        })
-      })
-  }
-
-  /**
-   * Transform constructors and their prototype methods to class syntax.
-   *
-   * @param {import("jscodeshift").Collection} root - The root AST collection.
-   * @param {Map<
-   *   object,
-   *   Map<
-   *     string,
-   *     {
-   *       constructorName: string
-   *       declaration: import("ast-types").NodePath
-   *       prototypeMethods: any[]
-   *     }
-   *   >
-   * >} constructorsByScope
-   *   - Map of constructors grouped by lexical scope.
-   *
-   * @returns {boolean} True if code was modified.
-   */
-  function transformConstructorsToClasses(root, constructorsByScope) {
-    let modified = false
-
-    constructorsByScope.forEach((constructors) => {
-      constructors.forEach((info) => {
-        if (info.prototypeMethods.length === 0) {
-          return
-        }
-
-        const constructorName = info.constructorName
-        const declarationPath = info.declaration
-        const declarationNode = declarationPath.node
-
-        let constructorNode
-        if (j.FunctionDeclaration.check(declarationNode)) {
-          constructorNode = declarationNode
-        } else {
-          const declarator = declarationNode.declarations.find(
-            (decl) => decl.id.name === constructorName,
-          )
-          constructorNode = declarator.init
-        }
-
-        const classBody = [
-          j.methodDefinition(
-            "constructor",
-            j.identifier("constructor"),
-            j.functionExpression(
-              null,
-              constructorNode.params,
-              constructorNode.body,
-              constructorNode.generator,
-              constructorNode.async,
-            ),
-            false,
-          ),
-        ]
-
-        info.prototypeMethods.forEach(({ methodName, methodValue }) => {
-          const functionExpr = j.functionExpression(
-            null,
-            methodValue.params,
-            new NodeTest(methodValue).toBlockStatement(),
-            methodValue.generator || false,
-          )
-
-          // Preserve async property
-          if (methodValue.async) {
-            functionExpr.async = true
-          }
-
-          const method = j.methodDefinition(
-            "method",
-            j.identifier(methodName),
-            functionExpr,
-            false,
-          )
-          classBody.push(method)
-        })
-
-        const classDeclaration = j.classDeclaration(
-          j.identifier(constructorName),
-          j.classBody(classBody),
-        )
-
-        classDeclaration.comments = declarationNode.comments
-
-        j(info.declaration).replaceWith(classDeclaration)
-
-        const pathsToRemove = new Set()
-        info.prototypeMethods.forEach(({ path }) => {
-          pathsToRemove.add(path)
-        })
-
-        pathsToRemove.forEach((path) => {
-          j(path).remove()
-        })
-
-        modified = true
-      })
-    })
-
-    return modified
-  }
-
   const constructorsByScope = findConstructors(root)
   findPrototypeMethods(root, constructorsByScope)
   return transformConstructorsToClasses(root, constructorsByScope)

--- a/tests/widelyAvailable/constructor-to-class.test.js
+++ b/tests/widelyAvailable/constructor-to-class.test.js
@@ -970,6 +970,44 @@ BaseClass.prototype.outer = function() {
       )
     })
 
+    test("do not leak duplicate-scope prototype object assignment to parent constructors", () => {
+      const result = transform(`
+function BaseClass() {}
+
+function wrapper() {
+  function BaseClass() {}
+  function BaseClass() {}
+
+  BaseClass.prototype = {
+    inner: function() {
+      return 'inner';
+    }
+  };
+}
+
+BaseClass.prototype = {
+  outer: function() {
+    return 'outer';
+  }
+};
+      `)
+
+      assert(result.modified, "transform unambiguous outer constructor")
+      const [wrapperCode, outerCode] = result.code.split("function wrapper()")
+      assert.match(wrapperCode, /class BaseClass/)
+      assert.match(wrapperCode, /outer\(\) \{/, "keep outer method on outer class")
+      assert.match(
+        outerCode,
+        /BaseClass\.prototype = \{/,
+        "keep ambiguous inner scope assignment untouched",
+      )
+      assert.doesNotMatch(
+        wrapperCode,
+        /inner\(\) \{/,
+        "avoid leaking duplicate-scope object assignment into parent constructor",
+      )
+    })
+
     test("transform multi-declarator constructors after safe splitting", () => {
       const result = transform(`
 var First = function() {}, Second = function() {};

--- a/tests/widelyAvailable/constructor-to-class.test.js
+++ b/tests/widelyAvailable/constructor-to-class.test.js
@@ -936,6 +936,40 @@ function wrapper() {
       assert.doesNotMatch(result.code, /class BaseClass/)
     })
 
+    test("do not leak duplicate-scope prototype methods to parent constructors", () => {
+      const result = transform(`
+function BaseClass() {}
+
+function wrapper() {
+  function BaseClass() {}
+  function BaseClass() {}
+
+  BaseClass.prototype.inner = function() {
+    return 'inner';
+  };
+}
+
+BaseClass.prototype.outer = function() {
+  return 'outer';
+};
+      `)
+
+      assert(result.modified, "transform unambiguous outer constructor")
+      const [wrapperCode, outerCode] = result.code.split("function wrapper()")
+      assert.match(wrapperCode, /class BaseClass/)
+      assert.match(wrapperCode, /outer\(\) \{/, "keep outer method on outer class")
+      assert.match(
+        outerCode,
+        /BaseClass\.prototype\.inner/,
+        "keep ambiguous inner scope assignment untouched",
+      )
+      assert.doesNotMatch(
+        wrapperCode,
+        /inner\(\) \{/,
+        "avoid leaking duplicate-scope method into parent constructor",
+      )
+    })
+
     test("transform multi-declarator constructors after safe splitting", () => {
       const result = transform(`
 var First = function() {}, Second = function() {};

--- a/tests/widelyAvailable/constructor-to-class.test.js
+++ b/tests/widelyAvailable/constructor-to-class.test.js
@@ -711,7 +711,7 @@ return this.value;
       assert.match(result.code, /class Empty/)
     })
 
-    test("keep prototype methods in matching scope", () => {
+    test("keep function declaration prototype methods in matching sibling scope", () => {
       const result = transform(`
 function firstSuite() {
   function BaseClass() {}
@@ -755,21 +755,69 @@ function secondSuite() {
       )
     })
 
-    test("keep repeated constructor names isolated in qunit tests", () => {
+    test("keep variable declaration prototype methods in matching sibling scope", () => {
       const result = transform(`
-QUnit.test('one', function (assert) {
+function firstSuite() {
+  var BaseClass = function() {};
+
+  BaseClass.prototype.first = function() {
+    return 'first';
+  };
+}
+
+function secondSuite() {
+  var BaseClass = function() {};
+
+  BaseClass.prototype.second = function() {
+    return 'second';
+  };
+}
+      `)
+
+      assert(result.modified, "transform both constructors")
+      assert.equal(result.code.split("first() {").length - 1, 1)
+      assert.equal(result.code.split("second() {").length - 1, 1)
+      const [firstSuiteCode, secondSuiteCode] = result.code.split(
+        "function secondSuite()",
+      )
+
+      assert.match(firstSuiteCode, /first\(\) \{/, "keep first method in first scope")
+      assert.doesNotMatch(
+        firstSuiteCode,
+        /second\(\) \{/,
+        "avoid leaking second method into first scope",
+      )
+      assert.match(
+        secondSuiteCode,
+        /second\(\) \{/,
+        "keep second method in second scope",
+      )
+      assert.doesNotMatch(
+        secondSuiteCode,
+        /first\(\) \{/,
+        "avoid leaking first method into second scope",
+      )
+    })
+
+    test("keep prototype object assignments in matching sibling scope", () => {
+      const result = transform(`
+QUnit.test('one', function(assert) {
   function BaseClass() {}
 
-  BaseClass.prototype.hello = function () {
-    return 'A';
+  BaseClass.prototype = {
+    hello: function() {
+      return 'A';
+    }
   };
 });
 
-QUnit.test('two', function (assert) {
+QUnit.test('two', function(assert) {
   function BaseClass() {}
 
-  BaseClass.prototype.goodbye = function () {
-    return 'B';
+  BaseClass.prototype = {
+    goodbye: function() {
+      return 'B';
+    }
   };
 });
       `)
@@ -794,6 +842,50 @@ QUnit.test('two', function (assert) {
         secondTestCode,
         /hello\(\) \{/,
         "avoid leaking hello into second test scope",
+      )
+    })
+
+    test("match prototype methods to the nearest constructor scope", () => {
+      const result = transform(`
+function outerSuite() {
+  function BaseClass() {}
+
+  function addOuterMethod() {
+    BaseClass.prototype.outer = function() {
+      return 'outer';
+    };
+  }
+
+  addOuterMethod();
+
+  function innerSuite() {
+    function BaseClass() {}
+
+    BaseClass.prototype.inner = function() {
+      return 'inner';
+    };
+  }
+}
+      `)
+
+      assert(result.modified, "transform constructors across nested scopes")
+      assert.equal(result.code.split("outer() {").length - 1, 1)
+      assert.equal(result.code.split("inner() {").length - 1, 1)
+      const [outerSuiteCode, innerSuiteCode] = result.code.split(
+        "function innerSuite()",
+      )
+
+      assert.match(outerSuiteCode, /outer\(\) \{/, "keep outer method on outer class")
+      assert.doesNotMatch(
+        outerSuiteCode,
+        /inner\(\) \{/,
+        "avoid leaking inner method into outer scope",
+      )
+      assert.match(innerSuiteCode, /inner\(\) \{/, "keep inner method on inner class")
+      assert.doesNotMatch(
+        innerSuiteCode,
+        /outer\(\) \{/,
+        "avoid leaking outer method into inner scope",
       )
     })
   })

--- a/tests/widelyAvailable/constructor-to-class.test.js
+++ b/tests/widelyAvailable/constructor-to-class.test.js
@@ -919,5 +919,55 @@ function outerSuite() {
         "avoid leaking outer method into inner scope",
       )
     })
+
+    test("skip duplicate constructor declarations in the same scope", () => {
+      const result = transform(`
+function wrapper() {
+  function BaseClass() {}
+  function BaseClass() {}
+
+  BaseClass.prototype.run = function() {
+    return 'run';
+  };
+}
+      `)
+
+      assert.match(result.code, /function BaseClass\(\) \{\}/)
+      assert.doesNotMatch(result.code, /class BaseClass/)
+    })
+
+    test("transform multi-declarator constructors after safe splitting", () => {
+      const result = transform(`
+var First = function() {}, Second = function() {};
+
+First.prototype.run = function() {
+  return 'first';
+};
+Second.prototype.stop = function() {
+  return 'second';
+};
+      `)
+
+      assert(result.modified, "transform after safe split")
+      assert.match(result.code, /class First/)
+      assert.match(result.code, /class Second/)
+    })
+
+    test("do not match constructors declared in child lexical scopes", () => {
+      const result = transform(`
+function wrapper() {
+  BaseClass.prototype.run = function() {
+    return 'run';
+  };
+
+  function setup() {
+    function BaseClass() {}
+  }
+}
+      `)
+
+      assert.match(result.code, /function BaseClass\(\) \{\}/)
+      assert.doesNotMatch(result.code, /class BaseClass/)
+    })
   })
 })

--- a/tests/widelyAvailable/constructor-to-class.test.js
+++ b/tests/widelyAvailable/constructor-to-class.test.js
@@ -710,5 +710,91 @@ return this.value;
       assert(result.modified, "transform function declaration with empty body")
       assert.match(result.code, /class Empty/)
     })
+
+    test("keep prototype methods in matching scope", () => {
+      const result = transform(`
+function firstSuite() {
+  function BaseClass() {}
+
+  BaseClass.prototype.first = function() {
+    return 'first';
+  };
+}
+
+function secondSuite() {
+  function BaseClass() {}
+
+  BaseClass.prototype.second = function() {
+    return 'second';
+  };
+}
+      `)
+
+      assert(result.modified, "transform both constructors")
+      assert.equal(result.code.split("first() {").length - 1, 1)
+      assert.equal(result.code.split("second() {").length - 1, 1)
+      const [firstSuiteCode, secondSuiteCode] = result.code.split(
+        "function secondSuite()",
+      )
+
+      assert.match(firstSuiteCode, /first\(\) \{/, "keep first method in first scope")
+      assert.doesNotMatch(
+        firstSuiteCode,
+        /second\(\) \{/,
+        "avoid leaking second method into first scope",
+      )
+      assert.match(
+        secondSuiteCode,
+        /second\(\) \{/,
+        "keep second method in second scope",
+      )
+      assert.doesNotMatch(
+        secondSuiteCode,
+        /first\(\) \{/,
+        "avoid leaking first method into second scope",
+      )
+    })
+
+    test("keep repeated constructor names isolated in qunit tests", () => {
+      const result = transform(`
+QUnit.test('one', function (assert) {
+  function BaseClass() {}
+
+  BaseClass.prototype.hello = function () {
+    return 'A';
+  };
+});
+
+QUnit.test('two', function (assert) {
+  function BaseClass() {}
+
+  BaseClass.prototype.goodbye = function () {
+    return 'B';
+  };
+});
+      `)
+
+      assert(result.modified, "transform both QUnit constructors")
+      assert.equal(result.code.split("hello() {").length - 1, 1)
+      assert.equal(result.code.split("goodbye() {").length - 1, 1)
+      const [firstTestCode, secondTestCode] = result.code.split("QUnit.test('two'")
+
+      assert.match(firstTestCode, /hello\(\) \{/, "keep hello in first test scope")
+      assert.doesNotMatch(
+        firstTestCode,
+        /goodbye\(\) \{/,
+        "avoid leaking goodbye into first test scope",
+      )
+      assert.match(
+        secondTestCode,
+        /goodbye\(\) \{/,
+        "keep goodbye in second test scope",
+      )
+      assert.doesNotMatch(
+        secondTestCode,
+        /hello\(\) \{/,
+        "avoid leaking hello into second test scope",
+      )
+    })
   })
 })


### PR DESCRIPTION
This PR addresses unresolved review feedback on `constructorToClass` by tightening constructor/prototype matching semantics and removing ambiguous transform paths. It also clarifies the documented scope rule to match implementation behavior.

- **Scope matching + lookup efficiency**
  - Refactors prototype-assignment matching to resolve constructor info once per node (no duplicate `getConstructor(...)` walk per match).
  - Keeps nearest lexical ancestor lookup behavior while preventing cross-scope leakage into sibling/child declarations.

- **Ambiguity handling for duplicate constructors**
  - Detects duplicate constructor names in the same lexical scope and marks them as ambiguous.
  - Skips class transformation for ambiguous entries instead of silently overwriting earlier constructor metadata.

- **Variable declaration safety**
  - Restricts constructor discovery from `VariableDeclaration` to single-declarator statements to avoid unsafe shared-node replacement behavior in multi-declarator declarations.

- **Behavioral regression coverage**
  - Adds targeted regression tests for:
    - duplicate constructor declarations in the same scope,
    - multi-declarator constructor declarations,
    - prototype assignment in parent scope with constructor declared in child scope.

- **README rule update**
  - Rewords scope criteria from “same lexical scope” to “current or ancestor lexical scope (never sibling/child scopes)” to align docs with runtime behavior.

```js
// before: ambiguous duplicate declarations could be overwritten
function wrapper() {
  function BaseClass() {}
  function BaseClass() {}
  BaseClass.prototype.run = function () { return "run" }
}

// after: duplicate-in-scope is treated as ambiguous and not transformed
```